### PR TITLE
adds getRayLeft(Right)Margin to robofab extras

### DIFF
--- a/content/API/robofabExtras/glyphObject.rst
+++ b/content/API/robofabExtras/glyphObject.rst
@@ -69,6 +69,15 @@ RoboFab Glyph Extras
     .. attribute:: angledRightMargin
 
         returns the angled right margin based on the italic angle in the font.info
+    
+    
+    .. attribute:: getRayLeftMargin(y)
+
+        returns the left margin at the value of y (similar to the beam)
+        
+    .. attribute:: getRayRightMargin(y)
+
+        returns the right margin at the value of y (similar to the beam)
 
     .. attribute:: mark
 


### PR DESCRIPTION
This adds the ray/beam value, as discussed in this old thread: http://doc.robofont.com/forums/topic/margins-from-beam/

Apologies if it's already in there somewhere. I couldn't find it.